### PR TITLE
Prevent request failure when there is only one Broker

### DIFF
--- a/src/main/java/com/symantec/cpe/analytics/kafka/KafkaConsumerOffsetUtil.java
+++ b/src/main/java/com/symantec/cpe/analytics/kafka/KafkaConsumerOffsetUtil.java
@@ -105,7 +105,10 @@ public class KafkaConsumerOffsetUtil {
         List<KafkaConsumerGroupMetadata> kafkaConsumerGroupMetadataList = zkClient.getActiveRegularConsumersAndTopics();
         List<KafkaOffsetMonitor> kafkaOffsetMonitors = new ArrayList<KafkaOffsetMonitor>();
         List<Broker> kafkaBrokers = getAllBrokers();
-        SimpleConsumer consumer = getConsumer(kafkaBrokers.get(1).host(), kafkaBrokers.get(1).port(), clientName);
+        if (kafkaBrokers.size() == 0)
+            throw new Exception("No brokers found");
+        Broker randomBroker = kafkaBrokers.get(kafkaBrokers.size() > 1 ? new Random().nextInt(kafkaBrokers.size() - 1) : 0);
+        SimpleConsumer consumer = getConsumer(randomBroker.host(), randomBroker.port(), clientName);
         for (KafkaConsumerGroupMetadata kafkaConsumerGroupMetadata : kafkaConsumerGroupMetadataList) {
             List<TopicPartitionLeader> partitions = getPartitions(consumer, kafkaConsumerGroupMetadata.getTopic());
             for (TopicPartitionLeader partition : partitions) {


### PR DESCRIPTION
Picking random broker instead of the second one (when getting regular Kafka offset information) in order  to prevent a request failure when there is only one  broker.
